### PR TITLE
Patch WeightInfo bug

### DIFF
--- a/src/weights.rs
+++ b/src/weights.rs
@@ -7,6 +7,8 @@ pub trait SystemWeight {
     type Proxy = ();
     type Multisig = ();
     type ParachainSystem = ();
+    type Balances = ();
+    type Utility = ();
     type DbWeight;
 }
 


### PR DESCRIPTION
Bug introduced in #41 -- this blocking https://github.com/OpenZeppelin/polkadot-runtime-templates/pull/380

Confirmed that this works in both templates https://github.com/OpenZeppelin/polkadot-runtime-templates/pull/380/commits/1a3550089035b59cf7a40ec39d6c2615679bbdb8